### PR TITLE
Introduce DaskReader with ts.virtual_chunked; unify get_tensorstore() API

### DIFF
--- a/src/tensorswitch_v2/__main__.py
+++ b/src/tensorswitch_v2/__main__.py
@@ -711,28 +711,15 @@ def _get_input_metadata(args):
         tuple: (shape, dtype_str, axes_order) where axes_order may be None
     """
     reader = create_reader(args)
-    spec = reader.get_tensorstore_spec()
-    if spec.get('driver') == 'array' and 'array' in spec:
-        arr = spec['array']
-        # Try to get axes from spec schema
-        axes_order = spec.get('schema', {}).get('dimension_names')
-        return tuple(arr.shape), str(arr.dtype), axes_order
-    else:
-        import tensorstore as ts
-        from .utils import get_tensorstore_context
-        spec['context'] = get_tensorstore_context()
-        store = ts.open(spec, read=True).result()
-        # Get axes from TensorStore domain labels (e.g., precomputed has ['x','y','z','channel'])
-        axes_order = None
-        if hasattr(store, 'domain') and hasattr(store.domain, 'labels'):
-            labels = store.domain.labels
-            if labels and all(labels):
-                # Normalize 'channel' to 'c'
-                axes_order = ['c' if l.lower() == 'channel' else l.lower() for l in labels]
-        # Fallback to spec schema if available
-        if not axes_order:
-            axes_order = spec.get('schema', {}).get('dimension_names')
-        return tuple(store.shape), store.dtype.name, axes_order
+    store = reader.get_tensorstore()
+    # Get axes from TensorStore domain labels
+    axes_order = None
+    if hasattr(store, 'domain') and hasattr(store.domain, 'labels'):
+        labels = store.domain.labels
+        if labels and all(labels):
+            # Normalize 'channel' to 'c'
+            axes_order = ['c' if l.lower() == 'channel' else l.lower() for l in labels]
+    return tuple(store.shape), store.dtype.name, axes_order
 
 
 def _estimate_shard_info(args, volume_shape, dtype_str, axes_order=None):
@@ -1077,22 +1064,18 @@ def show_conversion_spec(reader, writer, args, chunk_shape, shard_shape):
     if voxel_sizes:
         print(f"Voxel sizes: {voxel_sizes}")
 
-    # Try to get TensorStore spec (may not be available for all readers)
+    # Try to get TensorStore store info
     try:
-        input_spec = reader.get_tensorstore_spec()
-        print(f"\nTensorStore spec:")
-        # Simplify for display
-        display_spec = {
-            "driver": input_spec.get("driver"),
-            "dtype": input_spec.get("dtype"),
+        store = reader.get_tensorstore()
+        print(f"\nTensorStore info:")
+        display_info = {
+            "shape": list(store.shape),
+            "dtype": str(store.dtype),
+            "labels": list(store.domain.labels),
         }
-        if "kvstore" in input_spec:
-            kvstore = input_spec["kvstore"]
-            if isinstance(kvstore, dict):
-                display_spec["kvstore"] = kvstore.get("driver", kvstore)
-        print(json.dumps(display_spec, indent=2, default=str))
+        print(json.dumps(display_info, indent=2, default=str))
     except Exception as e:
-        print(f"(TensorStore spec not available: {e})")
+        print(f"(TensorStore info not available: {e})")
 
     # Output spec
     print("\n--- OUTPUT ---")
@@ -1643,16 +1626,8 @@ def main(argv=None):
         # Auto-detect based on dtype
         resolved_data_type = 'image'  # Default
         try:
-            spec = reader.get_tensorstore_spec()
-            if spec.get('driver') == 'array' and 'array' in spec:
-                dtype_str = str(spec['array'].dtype)
-            else:
-                import tensorstore as ts
-                from .utils import get_tensorstore_context
-                spec['context'] = get_tensorstore_context()
-                store = ts.open(spec, read=True).result()
-                dtype_str = store.dtype.name
-
+            store = reader.get_tensorstore()
+            dtype_str = store.dtype.name
             from .utils.metadata_utils import is_segmentation_dtype
             if is_segmentation_dtype(dtype_str):
                 is_label = True

--- a/src/tensorswitch_v2/api/dataset.py
+++ b/src/tensorswitch_v2/api/dataset.py
@@ -85,7 +85,7 @@ class TensorSwitchDataset:
         """
         self.path = path
         self._reader = reader
-        self._ts_spec_cache = None
+        self._ts_store_cache = None
         self._ts_array_cache = {}  # Cache for different modes
 
         # If no reader provided, will need auto-detection
@@ -96,29 +96,23 @@ class TensorSwitchDataset:
                 "Readers factory will be added in Day 4-5 (see PLAN_phase5.md)."
             )
 
-    def get_tensorstore_array(self, mode: str = "virtual") -> ts.TensorStore:
+    def get_tensorstore_array(self, mode: str = "open") -> ts.TensorStore:
         """
-        Return TensorStore array handle or spec.
+        Return TensorStore array handle.
 
         Three modes available:
-        - 'virtual': Returns spec dict (lazy, zero-copy) - default
-        - 'open': Returns opened TensorStore handle
+        - 'open': Returns opened TensorStore handle (default)
+        - 'virtual': Alias for 'open' (all stores are now opened via get_tensorstore())
         - 'copy': Returns in-memory TensorStore array
 
         Args:
-            mode: Access mode ('virtual', 'open', or 'copy')
+            mode: Access mode ('open', 'virtual', or 'copy')
 
         Returns:
-            TensorStore array or spec dict
+            ts.TensorStore: Opened TensorStore array
 
-        Example (virtual mode - default):
-            >>> spec = dataset.get_tensorstore_array(mode='virtual')
-            >>> # Returns dict, can be passed to ts.open() later
-            >>> ts_array = ts.open(spec).result()
-
-        Example (open mode):
-            >>> ts_array = dataset.get_tensorstore_array(mode='open')
-            >>> # Already opened, ready to read
+        Example (open mode - default):
+            >>> ts_array = dataset.get_tensorstore_array()
             >>> chunk_data = ts_array[0:10, :, :].read().result()
 
         Example (copy mode):
@@ -126,44 +120,29 @@ class TensorSwitchDataset:
             >>> # Data loaded into memory
 
         Notes:
-            - Virtual mode: Best for lazy evaluation, no I/O
-            - Open mode: Opens handle, I/O on read
-            - Copy mode: Loads all data into memory (use carefully!)
+            - 'open' and 'virtual' are now equivalent (both return get_tensorstore())
+            - 'copy': Loads all data into memory (use carefully!)
             - Results are cached per mode for efficiency
         """
         # Check cache first
         if mode in self._ts_array_cache:
             return self._ts_array_cache[mode]
 
-        if mode == "virtual":
-            # Return virtual spec (lazy, zero-copy)
-            spec = self.get_tensorstore_spec()
-            self._ts_array_cache[mode] = spec
-            return spec
-
-        elif mode == "open":
-            # Open TensorStore handle
-            spec = self.get_tensorstore_spec()
-            ts_array = ts.open(spec).result()
-            self._ts_array_cache[mode] = ts_array
-            return ts_array
+        if mode in ("virtual", "open"):
+            store = self.get_tensorstore()
+            self._ts_array_cache[mode] = store
+            return store
 
         elif mode == "copy":
-            # Read into memory, create in-memory TensorStore
-            spec = self.get_tensorstore_spec()
-            ts_array = ts.open(spec).result()
-
-            # Read all data
-            data = ts_array.read().result()
-
-            # Create in-memory TensorStore
+            store = self.get_tensorstore()
+            data = store[...].read().result()
             mem_spec = {
                 'driver': 'array',
                 'array': data,
                 'schema': {
                     'dtype': str(data.dtype),
                     'shape': list(data.shape),
-                    'dimension_names': spec.get('schema', {}).get('dimension_names', [])
+                    'dimension_names': list(store.domain.labels)
                 }
             }
             mem_array = ts.open(mem_spec).result()
@@ -171,30 +150,26 @@ class TensorSwitchDataset:
             return mem_array
 
         else:
-            raise ValueError(f"Unknown mode: {mode}. Use 'virtual', 'open', or 'copy'")
+            raise ValueError(f"Unknown mode: {mode}. Use 'open', 'virtual', or 'copy'")
 
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return TensorStore spec (virtual).
+        Return opened ts.TensorStore for this dataset.
 
-        Delegates to the reader's get_tensorstore_spec() method.
+        Delegates to the reader's get_tensorstore() method.
         Result is cached for efficiency.
 
         Returns:
-            dict: TensorStore spec with keys:
-                - 'driver': TensorStore driver name
-                - 'kvstore': Key-value store specification
-                - 'schema': Array schema (dtype, shape, dimension_names)
-                - Additional format-specific keys
+            ts.TensorStore: Opened store with correct shape, dtype, and domain labels.
 
         Example:
-            >>> spec = dataset.get_tensorstore_spec()
-            >>> print(spec['driver'])  # 'zarr3', 'n5', 'array', etc.
-            >>> print(spec['schema']['shape'])  # [100, 1024, 1024]
+            >>> store = dataset.get_tensorstore()
+            >>> print(store.shape)
+            >>> print(store.domain.labels)
         """
-        if self._ts_spec_cache is None:
-            self._ts_spec_cache = self._reader.get_tensorstore_spec()
-        return self._ts_spec_cache
+        if self._ts_store_cache is None:
+            self._ts_store_cache = self._reader.get_tensorstore()
+        return self._ts_store_cache
 
     def get_ome_ngff_metadata(self, version: str = "0.5") -> Dict:
         """
@@ -251,8 +226,7 @@ class TensorSwitchDataset:
             >>> dataset.shape
             (100, 1024, 1024)
         """
-        spec = self.get_tensorstore_spec()
-        return tuple(spec.get('schema', {}).get('shape', []))
+        return tuple(self.get_tensorstore().shape)
 
     @property
     def dtype(self) -> str:
@@ -263,8 +237,7 @@ class TensorSwitchDataset:
             >>> dataset.dtype
             'uint16'
         """
-        spec = self.get_tensorstore_spec()
-        return spec.get('schema', {}).get('dtype', 'unknown')
+        return str(self.get_tensorstore().dtype)
 
     @property
     def ndim(self) -> int:

--- a/src/tensorswitch_v2/core/converter.py
+++ b/src/tensorswitch_v2/core/converter.py
@@ -20,7 +20,6 @@ from ..writers.base import BaseWriter
 from ..utils import (
     get_chunk_domains,
     get_total_chunks_from_store,
-    get_tensorstore_context,
     detect_source_order,
     update_ome_metadata_if_needed,
 )
@@ -142,24 +141,9 @@ class DistributedConverter:
         # 1. Open input store from reader
         if verbose:
             print(f"Opening input: {self.reader}")
-        input_spec = self.reader.get_tensorstore_spec()
-
-        # Handle Tier 2 readers (dask arrays) vs Tier 1 (native TensorStore)
-        if input_spec.get('driver') == 'array' and 'array' in input_spec:
-            # Tier 2: Reader returns a dask array wrapped in 'array' driver
-            self._dask_array = input_spec['array']
-            self._input_store = None  # Will use dask array directly
-            input_shape = tuple(self._dask_array.shape)
-            input_dtype = _get_dtype_name(self._dask_array.dtype)
-            self._is_tier2 = True
-        else:
-            # Tier 1: Native TensorStore driver
-            input_spec['context'] = get_tensorstore_context()
-            self._input_store = ts.open(input_spec, read=True).result()
-            input_shape = tuple(self._input_store.shape)
-            input_dtype = _get_dtype_name(self._input_store.dtype)
-            self._is_tier2 = False
-            self._dask_array = None
+        self._input_store = self.reader.get_tensorstore()
+        input_shape = tuple(self._input_store.shape)
+        input_dtype = _get_dtype_name(self._input_store.dtype)
 
         if verbose:
             print(f"  Shape: {input_shape}, dtype: {input_dtype}")
@@ -168,8 +152,8 @@ class DistributedConverter:
         use_fortran_order = False
         axes_order = None
 
-        # First try to get actual domain labels from TensorStore (most accurate)
-        if not self._is_tier2 and self._input_store is not None:
+        # Get domain labels from TensorStore (works for both Tier 1 and virtual_chunked)
+        if self._input_store is not None:
             try:
                 domain_labels = list(self._input_store.domain.labels)
                 if domain_labels and all(isinstance(l, str) and l for l in domain_labels):
@@ -178,14 +162,6 @@ class DistributedConverter:
                         print(f"  Axes from TensorStore domain: {axes_order}")
             except Exception:
                 pass
-
-        # Fallback: try dimension_names from reader spec (CZI, etc.)
-        if axes_order is None:
-            reader_axes = input_spec.get('schema', {}).get('dimension_names')
-            if reader_axes and all(isinstance(a, str) for a in reader_axes):
-                axes_order = list(reader_axes)
-                if verbose:
-                    print(f"  Axes from reader: {axes_order}")
 
         # Handle order: force_order overrides auto-detection
         if force_order is not None:
@@ -197,8 +173,7 @@ class DistributedConverter:
         elif preserve_order:
             # Auto-detect from source
             try:
-                source_for_order = self._dask_array if self._is_tier2 else self._input_store
-                order_info = detect_source_order(source_for_order)
+                order_info = detect_source_order(self._input_store)
                 use_fortran_order = order_info.get('is_fortran_order', False)
                 # Only use detected axes if reader didn't provide them
                 if axes_order is None:
@@ -339,20 +314,9 @@ class DistributedConverter:
                     read_domain.insert(self._squeeze_axis, slice(0, 1))
                     read_domain = tuple(read_domain)
 
-                # Read from input (handle both Tier 1 and Tier 2 readers)
-                if self._is_tier2:
-                    # Tier 2: Read from dask array, need to convert domain to slices
-                    # read_domain may already be a tuple of slices
-                    if isinstance(read_domain, tuple) and all(isinstance(s, slice) for s in read_domain):
-                        slices = read_domain
-                    else:
-                        slices = self._domain_to_slices(read_domain)
-                    data = self._dask_array[slices].compute()
-                else:
-                    # Tier 1: Read from TensorStore directly
-                    # Pass order parameter to preserve source memory layout (F-order vs C-order)
-                    read_order = 'F' if getattr(self, '_use_fortran_order', False) else 'C'
-                    data = self._input_store[read_domain].read(order=read_order).result()
+                # Read from TensorStore (works uniformly for all reader tiers)
+                read_order = 'F' if getattr(self, '_use_fortran_order', False) else 'C'
+                data = self._input_store[read_domain].read(order=read_order).result()
 
                 # Squeeze singleton channel if we detected one
                 if self._squeeze_channel and self._squeeze_axis is not None:
@@ -453,20 +417,9 @@ class DistributedConverter:
         if self._total_chunks is not None:
             return self._total_chunks
 
-        # Get input shape (handle both Tier 1 and Tier 2 readers)
-        input_spec = self.reader.get_tensorstore_spec()
-
-        if input_spec.get('driver') == 'array' and 'array' in input_spec:
-            # Tier 2: Get shape from dask array
-            dask_array = input_spec['array']
-            input_shape = tuple(dask_array.shape)
-            input_dtype = _get_dtype_name(dask_array.dtype)
-        else:
-            # Tier 1: Open TensorStore to get shape
-            input_spec['context'] = get_tensorstore_context()
-            input_store = ts.open(input_spec, read=True).result()
-            input_shape = tuple(input_store.shape)
-            input_dtype = _get_dtype_name(input_store.dtype)
+        input_store = self.reader.get_tensorstore()
+        input_shape = tuple(input_store.shape)
+        input_dtype = _get_dtype_name(input_store.dtype)
 
         # Create temp output spec to get chunk layout
         output_spec = self.writer.create_output_spec(
@@ -518,23 +471,6 @@ class DistributedConverter:
             start = stop
 
         return ranges
-
-    def _domain_to_slices(self, domain) -> tuple:
-        """
-        Convert TensorStore IndexDomain to Python slice tuple for dask array indexing.
-
-        Args:
-            domain: TensorStore IndexDomain
-
-        Returns:
-            tuple: Tuple of slices for array indexing
-        """
-        slices = []
-        for i in range(domain.ndim):
-            start = int(domain.origin[i])
-            stop = start + int(domain.shape[i])
-            slices.append(slice(start, stop))
-        return tuple(slices)
 
     def __repr__(self) -> str:
         return f"DistributedConverter(reader={self.reader}, writer={self.writer})"

--- a/src/tensorswitch_v2/readers/__init__.py
+++ b/src/tensorswitch_v2/readers/__init__.py
@@ -39,7 +39,7 @@ Public API:
     - BaseReader: Abstract base class for all readers
 """
 
-from .base import BaseReader
+from .base import BaseReader, DaskReader
 
 # Tier 1: Native TensorStore
 from .n5 import N5Reader
@@ -61,7 +61,7 @@ from .bioformats import BioFormatsReader
 
 __all__ = [
     # Base
-    'BaseReader',
+    'BaseReader', 'DaskReader',
     # Tier 1
     'N5Reader', 'Zarr3Reader', 'Zarr2Reader', 'PrecomputedReader',
     # Tier 2

--- a/src/tensorswitch_v2/readers/base.py
+++ b/src/tensorswitch_v2/readers/base.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import os
 import json
 import numpy as np
+import tensorstore as ts
 
 
 # ============================================================================
@@ -139,7 +140,7 @@ class BaseReader(ABC):
     Example Usage:
         >>> from tensorswitch_v2.readers import TiffReader
         >>> reader = TiffReader("/path/to/data.tif")
-        >>> ts_spec = reader.get_tensorstore_spec()
+        >>> store = reader.get_tensorstore()
         >>> metadata = reader.get_metadata()
         >>> voxel_sizes = reader.get_voxel_sizes()
 
@@ -158,43 +159,28 @@ class BaseReader(ABC):
         self.path = path
 
     @abstractmethod
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return TensorStore specification for this data source.
+        Return an opened TensorStore for this data source.
 
-        This is the core conversion method - converts format-specific data
-        into a TensorStore spec (virtual or open).
+        This is the core access method - converts format-specific data
+        into an opened ts.TensorStore ready for reading.
 
         Returns:
-            dict: TensorStore spec with keys like:
-                - 'driver': TensorStore driver name (e.g., 'zarr3', 'n5', 'array')
-                - 'kvstore': Key-value store specification
-                - 'schema': Array schema (dtype, shape, dimension_names)
-                - 'open': True if opening existing data
+            ts.TensorStore: Opened store with shape, dtype, and domain labels set.
 
         Example (N5 - native TensorStore):
-            {
-                'driver': 'n5',
-                'kvstore': {'driver': 'file', 'path': '/data.n5'},
-                'open': True,
-                'schema': {'dimension_names': ['z', 'y', 'x']}
-            }
+            Opens via ts.open({'driver': 'n5', 'kvstore': ..., 'open': True})
+            and returns the result.
 
-        Example (TIFF - wrapped Dask array):
-            {
-                'driver': 'array',
-                'array': dask_array,  # Lazy Dask array
-                'schema': {
-                    'dtype': 'uint16',
-                    'shape': [100, 1024, 1024],
-                    'dimension_names': ['z', 'y', 'x']
-                }
-            }
+        Example (TIFF/ND2/IMS - DaskReader subclass):
+            Returns ts.virtual_chunked(self._read_fn, ...) backed by a dask array.
 
         Notes:
-            - Prefer virtual/lazy specs when possible (avoid loading data)
-            - For non-TensorStore formats, wrap in Dask then use 'array' driver
-            - Include dimension_names for dimension-aware processing
+            - Tier 1 readers (N5, Zarr, Precomputed) call ts.open() on a spec dict.
+            - Tier 2+ readers (DaskReader subclasses) use ts.virtual_chunked().
+            - The returned store is always already opened; callers need not call
+              ts.open() again.
         """
         pass
 
@@ -306,13 +292,12 @@ class BaseReader(ABC):
             - Subclasses should override to extract format-specific info
             - Missing fields will be None or have sensible defaults
         """
-        # Get basic info from spec
-        spec = self.get_tensorstore_spec()
-        schema = spec.get('schema', {})
+        # Get basic info from the opened store
+        store = self.get_tensorstore()
 
-        shape = tuple(schema.get('shape', []))
-        dtype = schema.get('dtype', 'unknown')
-        dimension_names = schema.get('dimension_names', [])
+        shape = tuple(store.shape)
+        dtype = str(store.dtype)
+        dimension_names = list(store.domain.labels)
 
         # Get voxel sizes
         try:
@@ -435,10 +420,10 @@ class BaseReader(ABC):
         Returns:
             dict: Basic OME-NGFF metadata structure
         """
-        # Get array shape from TensorStore spec
-        spec = self.get_tensorstore_spec()
-        shape = spec.get('schema', {}).get('shape', [])
-        dimension_names = spec.get('schema', {}).get('dimension_names', [])
+        # Get array shape from the opened store
+        store = self.get_tensorstore()
+        shape = list(store.shape)
+        dimension_names = list(store.domain.labels)
 
         # Infer dimension names if not provided
         if not dimension_names:
@@ -547,3 +532,98 @@ class BaseReader(ABC):
     def __repr__(self) -> str:
         """String representation of reader."""
         return f"{self.__class__.__name__}(path='{self.path}')"
+
+
+class DaskReader(BaseReader, ABC):
+    """
+    Intermediate base class for dask-backed readers (Tier 2+).
+
+    Subclasses implement _load() to populate self._dask_array with a lazy
+    dask array sourced from their native library (tifffile, nd2, h5py, etc.).
+    This class implements get_tensorstore() using ts.virtual_chunked, which
+    wraps the dask array in a real ts.TensorStore backed by a synchronous
+    _read_fn callback. TensorStore automatically dispatches _read_fn on its
+    thread pool — no async handling required.
+
+    The virtual_chunked chunk shape is set to match the dask array's native
+    chunk shape, so reads align with native chunking and avoid cross-chunk I/O.
+
+    Architecture Layer: 1 (Foundation - No Dependencies)
+    Tier: 2+ (Dask-backed)
+
+    Subclass Requirements:
+        Must implement _load() to set self._dask_array.
+        Optionally override _get_dimension_names() for format-specific axes.
+    """
+
+    def __init__(self, path: str):
+        super().__init__(path)
+        self._dask_array = None  # populated by _load()
+
+    @abstractmethod
+    def _load(self):
+        """
+        Populate self._dask_array with the format's data as a dask array.
+
+        Must be idempotent: guard the body with ``if self._dask_array is not None: return``.
+        Called automatically by get_tensorstore() before creating the virtual store.
+        """
+        pass
+
+    def _read_fn(self, domain, array, read_params):
+        """
+        Synchronous read callback for ts.virtual_chunked.
+
+        Slices self._dask_array to fill the pre-allocated output buffer.
+        TensorStore dispatches this on a thread pool, so blocking dask
+        compute() calls are safe here.
+        """
+        slices = tuple(
+            slice(int(domain.origin[i]), int(domain.origin[i]) + int(domain.shape[i]))
+            for i in range(domain.ndim)
+        )
+        array[...] = self._dask_array[slices].compute()
+
+    def _get_dimension_names(self):
+        """
+        Return axis labels for the array domain.
+
+        Default implementation infers names from shape (ZYX/CZYX/TCZYX).
+        Override in subclasses to use format-specific metadata instead
+        (e.g., tifffile axes string, ND2 dimension order).
+        """
+        return self._infer_dimension_names(self._dask_array.shape)
+
+    def _infer_dimension_names(self, shape):
+        """Infer standard dimension names from array shape."""
+        ndim = len(shape)
+        defaults = {
+            2: ['y', 'x'],
+            3: ['z', 'y', 'x'],
+            4: ['c', 'z', 'y', 'x'],
+            5: ['t', 'c', 'z', 'y', 'x'],
+        }
+        return defaults.get(ndim, [f'dim_{i}' for i in range(ndim)])
+
+    def get_tensorstore(self) -> ts.TensorStore:
+        """
+        Return a ts.TensorStore backed by the dask array via virtual_chunked.
+
+        Calls _load() to ensure self._dask_array is populated, then creates
+        a virtual_chunked store whose read chunk shape matches the dask array's
+        native chunk shape.
+
+        Returns:
+            ts.TensorStore: Opened virtual store with correct shape, dtype, and
+                domain labels.
+        """
+        self._load()
+        shape = list(self._dask_array.shape)
+        dtype = self._dask_array.dtype
+        native_chunk_shape = [int(c[0]) for c in self._dask_array.chunks]
+        return ts.virtual_chunked(
+            self._read_fn,
+            dtype=ts.dtype(dtype),
+            domain=ts.IndexDomain(shape=shape, labels=self._get_dimension_names()),
+            chunk_layout=ts.ChunkLayout(read_chunk_shape=native_chunk_shape),
+        )

--- a/src/tensorswitch_v2/readers/bioio_adapter.py
+++ b/src/tensorswitch_v2/readers/bioio_adapter.py
@@ -6,10 +6,10 @@ Converts BIOIO's dask arrays to TensorStore intermediate format.
 """
 
 from typing import Dict, Optional, List, Any
-from .base import BaseReader
+from .base import DaskReader
 
 
-class BIOIOReader(BaseReader):
+class BIOIOReader(DaskReader):
     """
     Reader adapter for BIOIO library, supporting 20+ microscopy formats.
 
@@ -226,44 +226,11 @@ class BIOIOReader(BaseReader):
         self._dask_array = dask_data
         return self._dask_array
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping BIOIO's dask array.
-
-        Converts BIOIO's dask array to TensorStore's 'array' driver format,
-        which serves as the intermediate representation.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping dask array
-
-        Example:
-            >>> reader = BIOIOReader("/data.czi")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'array'
-
-        Notes:
-            - BIOIO returns dask arrays in TCZYX order
-            - Singleton T/C dimensions are squeezed
-            - Final order is typically ZYX (3D) or CZYX (4D) or TCZYX (5D)
-        """
-        dask_array = self._get_dask_array()
-
-        # Infer dimension names based on final shape
-        dimension_names = self._infer_dimension_names(dask_array.shape)
-
-        # Wrap dask array in TensorStore 'array' driver
-        spec = {
-            'driver': 'array',
-            'array': dask_array,
-            'schema': {
-                'dtype': str(dask_array.dtype),
-                'shape': list(dask_array.shape),
-                'dimension_names': dimension_names
-            }
-        }
-
-        return spec
+    def _load(self):
+        """Load BIOIO dask array into self._dask_array."""
+        if self._dask_array is not None:
+            return
+        self._dask_array = self._get_dask_array()
 
     def get_metadata(self) -> Dict:
         """

--- a/src/tensorswitch_v2/readers/czi.py
+++ b/src/tensorswitch_v2/readers/czi.py
@@ -8,10 +8,10 @@ Uses pylibCZIrw directly (not bioio-czi) to avoid scene name parsing bugs.
 from typing import Dict, Optional, List
 # Import utility functions from v2 utils (independent from v1)
 from ..utils import load_czi_stack, extract_czi_metadata
-from .base import BaseReader
+from .base import DaskReader
 
 
-class CZIReader(BaseReader):
+class CZIReader(DaskReader):
     """
     Reader for Zeiss CZI format using existing load_czi_stack function.
 
@@ -67,25 +67,9 @@ class CZIReader(BaseReader):
             self.path, view_index=self._view_index
         )
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping Dask array from load_czi_stack.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping Dask array
-        """
-        self._load()
-
-        spec = {
-            'driver': 'array',
-            'array': self._dask_array,
-            'schema': {
-                'dtype': str(self._dask_array.dtype),
-                'shape': list(self._dask_array.shape),
-                'dimension_names': self.axes_order or self._infer_dimension_names(self._dask_array.shape)
-            }
-        }
-        return spec
+    def _get_dimension_names(self):
+        """Return CZI axes order or infer from shape."""
+        return self.axes_order or self._infer_dimension_names(self._dask_array.shape)
 
     def get_metadata(self) -> Dict:
         """
@@ -190,7 +174,7 @@ class CZIReader(BaseReader):
         return ['t' if ax == 'v' else ax for ax in self._axes_order]
 
     def _infer_dimension_names(self, shape):
-        """Infer dimension names from array shape."""
+        """Infer CZI-specific dimension names from shape (5D uses 'v' for views)."""
         ndim = len(shape)
         if ndim == 3:
             return ['z', 'y', 'x']

--- a/src/tensorswitch_v2/readers/hdf5.py
+++ b/src/tensorswitch_v2/readers/hdf5.py
@@ -6,10 +6,10 @@ Tier 2 reader - new implementation for HDF5 format.
 
 from typing import Dict, Optional, List
 import dask.array as da
-from .base import BaseReader
+from .base import DaskReader
 
 
-class HDF5Reader(BaseReader):
+class HDF5Reader(DaskReader):
     """
     Reader for generic HDF5 files.
 
@@ -167,49 +167,13 @@ class HDF5Reader(BaseReader):
         find_all(h5file)
         return datasets
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping Dask array from HDF5 dataset.
-
-        Opens the HDF5 file, creates a Dask array for lazy access,
-        and wraps it in TensorStore's 'array' driver.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping Dask array
-
-        Example:
-            >>> reader = HDF5Reader("/data.h5", dataset_path="/volume")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'array'
-        """
-        if self._dask_array is None:
-            dataset = self._open_dataset()
-
-            # Determine chunk shape
-            if self._chunk_shape:
-                chunks = self._chunk_shape
-            elif dataset.chunks:
-                chunks = dataset.chunks
-            else:
-                # Default chunking for non-chunked datasets
-                chunks = 'auto'
-
-            # Create dask array from HDF5 dataset
-            self._dask_array = da.from_array(dataset, chunks=chunks)
-
-        # Wrap Dask array in TensorStore 'array' driver
-        spec = {
-            'driver': 'array',
-            'array': self._dask_array,
-            'schema': {
-                'dtype': str(self._dask_array.dtype),
-                'shape': list(self._dask_array.shape),
-                'dimension_names': self._infer_dimension_names(self._dask_array.shape)
-            }
-        }
-
-        return spec
+    def _load(self):
+        """Open the HDF5 dataset and create a dask array for lazy access."""
+        if self._dask_array is not None:
+            return
+        dataset = self._open_dataset()
+        chunks = self._chunk_shape or dataset.chunks or 'auto'
+        self._dask_array = da.from_array(dataset, chunks=chunks)
 
     def get_metadata(self) -> Dict:
         """
@@ -304,20 +268,6 @@ class HDF5Reader(BaseReader):
             'y': convert_to_nanometers(metadata.get('voxel_size_y', 1.0), unit),
             'z': convert_to_nanometers(metadata.get('voxel_size_z', 1.0), unit)
         }
-
-    def _infer_dimension_names(self, shape):
-        """Infer dimension names from array shape."""
-        ndim = len(shape)
-        if ndim == 2:
-            return ['y', 'x']
-        elif ndim == 3:
-            return ['z', 'y', 'x']
-        elif ndim == 4:
-            return ['c', 'z', 'y', 'x']
-        elif ndim == 5:
-            return ['t', 'c', 'z', 'y', 'x']
-        else:
-            return [f'dim_{i}' for i in range(ndim)]
 
     def __del__(self):
         """Close HDF5 file on cleanup."""

--- a/src/tensorswitch_v2/readers/ims.py
+++ b/src/tensorswitch_v2/readers/ims.py
@@ -9,10 +9,10 @@ from typing import Dict, List, Optional
 import h5py
 # Import utility functions from v2 utils (independent from v1)
 from ..utils import load_ims_stack, extract_ims_metadata
-from .base import BaseReader
+from .base import DaskReader
 
 
-class IMSReader(BaseReader):
+class IMSReader(DaskReader):
     """
     Reader for Imaris IMS format using existing load_ims_stack function.
 
@@ -103,46 +103,9 @@ class IMSReader(BaseReader):
             print(f"Warning: Could not extract IMS dimension names: {e}")
             self._dimension_names = None
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping Dask array from load_ims_stack.
-
-        Reuses existing load_ims_stack() function which returns a Dask array,
-        then wraps it in TensorStore's 'array' driver.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping Dask array
-
-        Example:
-            >>> reader = IMSReader("/data.ims")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'array'
-            >>> print(spec['schema']['dimension_names'])  # Auto-detected
-            ['z', 'y', 'x']
-
-        Notes:
-            - Tier 2 approach: Dask array -> TensorStore 'array' driver
-            - Minimal overhead (one Dask layer)
-            - Dimension names auto-detected from IMS HDF5 structure
-        """
-        self._load()
-
-        # Use auto-detected dimension names, fall back to inference
-        dimension_names = self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
-
-        # Wrap Dask array in TensorStore 'array' driver
-        spec = {
-            'driver': 'array',
-            'array': self._dask_array,
-            'schema': {
-                'dtype': str(self._dask_array.dtype),
-                'shape': list(self._dask_array.shape),
-                'dimension_names': dimension_names
-            }
-        }
-
-        return spec
+    def _get_dimension_names(self):
+        """Return dimension names from IMS HDF5 structure or infer from shape."""
+        return self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
 
     def get_metadata(self) -> Dict:
         """
@@ -221,18 +184,6 @@ class IMSReader(BaseReader):
             'y': metadata.get('voxel_size_y', 1.0),
             'z': metadata.get('voxel_size_z', 1.0)
         }
-
-    def _infer_dimension_names(self, shape):
-        """Infer dimension names from array shape."""
-        ndim = len(shape)
-        if ndim == 3:
-            return ['z', 'y', 'x']
-        elif ndim == 4:
-            return ['c', 'z', 'y', 'x']
-        elif ndim == 5:
-            return ['t', 'c', 'z', 'y', 'x']
-        else:
-            return [f'dim_{i}' for i in range(ndim)]
 
     def __repr__(self) -> str:
         """String representation of IMS reader."""

--- a/src/tensorswitch_v2/readers/n5.py
+++ b/src/tensorswitch_v2/readers/n5.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import tensorstore as ts
 from .base import BaseReader
 from ..utils.format_loaders import convert_to_nanometers
+from ..utils import get_tensorstore_context
 
 
 def _parse_remote_url(url: str) -> Tuple[str, dict]:
@@ -119,42 +120,24 @@ class N5Reader(BaseReader):
         self._metadata_cache = None
         self._full_path = os.path.join(path, dataset_path) if dataset_path else path
 
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return TensorStore spec using native N5 driver.
+        Return an opened TensorStore using the native N5 driver.
 
         This is a Tier 1 reader - uses TensorStore's native N5 driver
         with zero conversion overhead.
 
         Returns:
-            dict: TensorStore spec for N5 dataset with keys:
-                - 'driver': 'n5'
-                - 'kvstore': Path to N5 container
-                - 'path': Dataset path within container (if multi-scale)
-                - 'open': True (opening existing data)
-                - 'schema': Dimension names if available
+            ts.TensorStore: Opened store for the N5 dataset.
 
         Example:
-            >>> reader = N5Reader("/data.n5")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec)
-            {
-                'driver': 'n5',
-                'kvstore': {'driver': 'file', 'path': '/data.n5'},
-                'open': True,
-                'schema': {'dimension_names': ['z', 'y', 'x']}
-            }
-
-        Example (multi-scale):
             >>> reader = N5Reader("/data.n5", dataset_path="s0")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['path'])
-            's0'
+            >>> store = reader.get_tensorstore()
+            >>> print(store.shape)
 
         Notes:
             - Native N5 driver = maximum performance
             - Supports remote kvstores (http, gcs, s3)
-            - Lazy evaluation (doesn't read data)
             - Compression handled by TensorStore automatically
         """
         # Detect URL scheme and use appropriate kvstore driver
@@ -163,17 +146,15 @@ class N5Reader(BaseReader):
         spec = {
             'driver': 'n5',
             'kvstore': kvstore_spec,
-            'open': True
+            'open': True,
+            'context': get_tensorstore_context(),
         }
 
         # Add dataset path if specified (for multi-scale N5)
         if self.dataset_path:
             spec['path'] = self.dataset_path
 
-        # Note: N5 driver doesn't support dimension_names in schema
-        # Dimension names are stored separately in metadata for reference
-
-        return spec
+        return ts.open(spec, read=True).result()
 
     def get_metadata(self) -> Dict:
         """

--- a/src/tensorswitch_v2/readers/nd2.py
+++ b/src/tensorswitch_v2/readers/nd2.py
@@ -9,10 +9,10 @@ from typing import Dict, List, Optional
 import nd2
 # Import utility functions from v2 utils (independent from v1)
 from ..utils import load_nd2_stack, extract_nd2_ome_metadata
-from .base import BaseReader
+from .base import DaskReader
 
 
-class ND2Reader(BaseReader):
+class ND2Reader(DaskReader):
     """
     Reader for Nikon ND2 format using existing load_nd2_stack function.
 
@@ -76,46 +76,9 @@ class ND2Reader(BaseReader):
             print(f"Warning: Could not extract ND2 dimension names: {e}")
             self._dimension_names = None
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping Dask array from load_nd2_stack.
-
-        Reuses existing load_nd2_stack() function which returns a Dask array,
-        then wraps it in TensorStore's 'array' driver.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping Dask array
-
-        Example:
-            >>> reader = ND2Reader("/data.nd2")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'array'
-            >>> print(spec['schema']['dimension_names'])  # Auto-detected
-            ['z', 'y', 'x']
-
-        Notes:
-            - Tier 2 approach: Dask array -> TensorStore 'array' driver
-            - Minimal overhead (one Dask layer)
-            - Dimension names auto-detected from ND2 file metadata
-        """
-        self._load()
-
-        # Use auto-detected dimension names, fall back to inference
-        dimension_names = self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
-
-        # Wrap Dask array in TensorStore 'array' driver
-        spec = {
-            'driver': 'array',
-            'array': self._dask_array,
-            'schema': {
-                'dtype': str(self._dask_array.dtype),
-                'shape': list(self._dask_array.shape),
-                'dimension_names': dimension_names
-            }
-        }
-
-        return spec
+    def _get_dimension_names(self):
+        """Return dimension names from ND2 metadata or infer from shape."""
+        return self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
 
     def get_metadata(self) -> Dict:
         """
@@ -173,18 +136,6 @@ class ND2Reader(BaseReader):
             'y': metadata.get('voxel_size_y', 1.0),
             'z': metadata.get('voxel_size_z', 1.0)
         }
-
-    def _infer_dimension_names(self, shape):
-        """Infer dimension names from array shape."""
-        ndim = len(shape)
-        if ndim == 3:
-            return ['z', 'y', 'x']
-        elif ndim == 4:
-            return ['c', 'z', 'y', 'x']
-        elif ndim == 5:
-            return ['t', 'c', 'z', 'y', 'x']
-        else:
-            return [f'dim_{i}' for i in range(ndim)]
 
     def __repr__(self) -> str:
         """String representation of ND2 reader."""

--- a/src/tensorswitch_v2/readers/precomputed.py
+++ b/src/tensorswitch_v2/readers/precomputed.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 import tensorstore as ts
 from .base import BaseReader, build_kvstore, is_remote_path
 from ..utils.format_loaders import extract_precomputed_metadata
+from ..utils import get_tensorstore_context
 
 
 class PrecomputedReader(BaseReader):
@@ -58,27 +59,24 @@ class PrecomputedReader(BaseReader):
         super().__init__(path)
         self.scale_index = scale_index
 
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return TensorStore spec using native Neuroglancer Precomputed driver.
+        Return an opened TensorStore using the native Neuroglancer Precomputed driver.
 
         This is a Tier 1 reader - uses TensorStore's native driver
         with zero conversion overhead. Supports local paths and remote URLs.
 
         Returns:
-            dict: TensorStore spec for Precomputed dataset
+            ts.TensorStore: Opened store for the Precomputed dataset.
 
         Example (remote GCS):
             >>> reader = PrecomputedReader("precomputed://gs://bucket/data")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['kvstore'])
-            {'driver': 'gcs', 'bucket': 'bucket', 'path': 'data'}
+            >>> store = reader.get_tensorstore()
+            >>> print(store.shape)
 
         Example (local path):
             >>> reader = PrecomputedReader("/path/to/precomputed_data")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['kvstore'])
-            {'driver': 'file', 'path': '/path/to/precomputed_data'}
+            >>> store = reader.get_tensorstore()
 
         Notes:
             - Native driver = maximum performance
@@ -90,17 +88,17 @@ class PrecomputedReader(BaseReader):
         if clean_path.startswith('precomputed://'):
             clean_path = clean_path[len('precomputed://'):]
 
-        # Build kvstore using shared utility (handles local, gs://, s3://, http://)
         kvstore = build_kvstore(clean_path)
 
         spec = {
             'driver': 'neuroglancer_precomputed',
             'kvstore': kvstore,
             'scale_index': self.scale_index,
-            'open': True
+            'open': True,
+            'context': get_tensorstore_context(),
         }
 
-        return spec
+        return ts.open(spec, read=True).result()
 
     def get_metadata(self) -> Dict:
         """
@@ -126,9 +124,8 @@ class PrecomputedReader(BaseReader):
         info, _ = extract_precomputed_metadata(self.path, self.scale_index)
 
         # Also get basic info from TensorStore for shape/dtype
-        spec = self.get_tensorstore_spec()
         try:
-            store = ts.open(spec).result()
+            store = self.get_tensorstore()
             metadata = {
                 'shape': list(store.shape),
                 'dtype': str(store.dtype),

--- a/src/tensorswitch_v2/readers/tiff.py
+++ b/src/tensorswitch_v2/readers/tiff.py
@@ -9,10 +9,10 @@ from typing import Dict, List, Optional
 import tifffile
 # Import utility functions from v2 utils (independent from v1)
 from ..utils import load_tiff_stack, extract_tiff_ome_metadata
-from .base import BaseReader
+from .base import DaskReader
 
 
-class TiffReader(BaseReader):
+class TiffReader(DaskReader):
     """
     Reader for TIFF format using existing load_tiff_stack function.
 
@@ -84,46 +84,9 @@ class TiffReader(BaseReader):
             print(f"Warning: Could not extract TIFF dimension names: {e}")
             self._dimension_names = None
 
-    def get_tensorstore_spec(self) -> Dict:
-        """
-        Return TensorStore spec wrapping Dask array from load_tiff_stack.
-
-        Reuses existing load_tiff_stack() function which returns a Dask array,
-        then wraps it in TensorStore's 'array' driver.
-
-        Returns:
-            dict: TensorStore spec with 'array' driver wrapping Dask array
-
-        Example:
-            >>> reader = TiffReader("/data.tif")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'array'
-            >>> print(spec['schema']['dimension_names'])  # Auto-detected
-            ['z', 'y', 'x']
-
-        Notes:
-            - Tier 2 approach: Dask array → TensorStore 'array' driver
-            - Minimal overhead (one Dask layer)
-            - Dimension names auto-detected from TIFF axes metadata
-        """
-        self._load()
-
-        # Use auto-detected dimension names, fall back to inference
-        dimension_names = self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
-
-        # Wrap Dask array in TensorStore 'array' driver
-        spec = {
-            'driver': 'array',
-            'array': self._dask_array,
-            'schema': {
-                'dtype': str(self._dask_array.dtype),
-                'shape': list(self._dask_array.shape),
-                'dimension_names': dimension_names
-            }
-        }
-
-        return spec
+    def _get_dimension_names(self):
+        """Return dimension names from TIFF metadata or infer from shape."""
+        return self._dimension_names or self._infer_dimension_names(self._dask_array.shape)
 
     def get_metadata(self) -> Dict:
         """
@@ -195,18 +158,6 @@ class TiffReader(BaseReader):
 
         # Default
         return {'x': 1.0, 'y': 1.0, 'z': 1.0}
-
-    def _infer_dimension_names(self, shape):
-        """Infer dimension names from array shape."""
-        ndim = len(shape)
-        if ndim == 3:
-            return ['z', 'y', 'x']
-        elif ndim == 4:
-            return ['c', 'z', 'y', 'x']
-        elif ndim == 5:
-            return ['t', 'c', 'z', 'y', 'x']
-        else:
-            return [f'dim_{i}' for i in range(ndim)]
 
     def __repr__(self) -> str:
         """String representation of TIFF reader."""

--- a/src/tensorswitch_v2/readers/zarr.py
+++ b/src/tensorswitch_v2/readers/zarr.py
@@ -8,7 +8,9 @@ Contains both Zarr3Reader and Zarr2Reader.
 from typing import Dict, Optional, List
 import os
 import json
+import tensorstore as ts
 from .base import BaseReader
+from ..utils import get_tensorstore_context
 
 
 class Zarr3Reader(BaseReader):
@@ -66,36 +68,29 @@ class Zarr3Reader(BaseReader):
         self._dataset_path = dataset_path
         self._metadata_cache = None
 
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return native TensorStore spec for Zarr3.
-
-        Creates a TensorStore spec using the 'zarr3' driver for
-        direct, high-performance access to Zarr3 data.
+        Return an opened TensorStore using the native Zarr3 driver.
 
         Returns:
-            dict: TensorStore spec with 'zarr3' driver
+            ts.TensorStore: Opened store for the Zarr3 dataset.
 
         Example:
             >>> reader = Zarr3Reader("/data.zarr", dataset_path="s0")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'zarr3'
+            >>> store = reader.get_tensorstore()
+            >>> print(store.shape)
 
         Notes:
             - Tier 1: Direct TensorStore driver, zero conversion overhead
             - Supports local files, GCS, S3, and HTTP
         """
-        # Build kvstore based on path type
-        kvstore = self._build_kvstore()
-
         spec = {
             'driver': 'zarr3',
-            'kvstore': kvstore,
+            'kvstore': self._build_kvstore(),
             'open': True,
+            'context': get_tensorstore_context(),
         }
-
-        return spec
+        return ts.open(spec, read=True).result()
 
     def _build_kvstore(self) -> Dict:
         """
@@ -291,32 +286,25 @@ class Zarr2Reader(BaseReader):
         self._dataset_path = dataset_path
         self._metadata_cache = None
 
-    def get_tensorstore_spec(self) -> Dict:
+    def get_tensorstore(self) -> ts.TensorStore:
         """
-        Return native TensorStore spec for Zarr2.
-
-        Creates a TensorStore spec using the 'zarr' driver for
-        direct, high-performance access to Zarr2 data.
+        Return an opened TensorStore using the native Zarr2 driver.
 
         Returns:
-            dict: TensorStore spec with 'zarr' driver
+            ts.TensorStore: Opened store for the Zarr2 dataset.
 
         Example:
             >>> reader = Zarr2Reader("/data.zarr")
-            >>> spec = reader.get_tensorstore_spec()
-            >>> print(spec['driver'])
-            'zarr'
+            >>> store = reader.get_tensorstore()
+            >>> print(store.shape)
         """
-        # Build kvstore based on path type
-        kvstore = self._build_kvstore()
-
         spec = {
             'driver': 'zarr',  # TensorStore uses 'zarr' for v2
-            'kvstore': kvstore,
+            'kvstore': self._build_kvstore(),
             'open': True,
+            'context': get_tensorstore_context(),
         }
-
-        return spec
+        return ts.open(spec, read=True).result()
 
     def _build_kvstore(self) -> Dict:
         """Build kvstore spec based on path type."""

--- a/tests/tensorswitch_v2/test_readers.py
+++ b/tests/tensorswitch_v2/test_readers.py
@@ -7,9 +7,11 @@ Tests all reader implementations (Tier 1, 2, 3) for correct behavior.
 import os
 import pytest
 import numpy as np
+import tensorstore as ts
 
 from tensorswitch_v2.readers import (
     BaseReader,
+    DaskReader,
     N5Reader,
     Zarr3Reader,
     Zarr2Reader,
@@ -27,13 +29,14 @@ class TestTiffReader:
         reader = TiffReader(sample_tiff_path)
         assert reader.path == sample_tiff_path
 
-    def test_get_tensorstore_spec(self, sample_tiff_path):
-        """Test getting TensorStore spec from TIFF."""
+    def test_get_tensorstore(self, sample_tiff_path):
+        """Test getting TensorStore from TIFF."""
         reader = TiffReader(sample_tiff_path)
-        spec = reader.get_tensorstore_spec()
+        store = reader.get_tensorstore()
 
-        assert spec is not None
-        assert 'driver' in spec
+        assert store is not None
+        assert isinstance(store, ts.TensorStore)
+        assert isinstance(reader, DaskReader)
 
     def test_get_metadata(self, sample_tiff_path):
         """Test getting metadata from TIFF."""
@@ -63,13 +66,13 @@ class TestZarr3Reader:
         reader = Zarr3Reader(sample_zarr3_path)
         assert reader.path == sample_zarr3_path
 
-    def test_get_tensorstore_spec(self, sample_zarr3_path):
-        """Test getting TensorStore spec from Zarr3."""
+    def test_get_tensorstore(self, sample_zarr3_path):
+        """Test getting TensorStore from Zarr3."""
         reader = Zarr3Reader(sample_zarr3_path, dataset_path="s0")
-        spec = reader.get_tensorstore_spec()
+        store = reader.get_tensorstore()
 
-        assert spec is not None
-        assert spec['driver'] == 'zarr3'
+        assert isinstance(store, ts.TensorStore)
+        assert store.spec().to_json()['driver'] == 'zarr3'
 
     def test_get_metadata(self, sample_zarr3_path):
         """Test getting metadata from Zarr3."""
@@ -94,13 +97,13 @@ class TestZarr2Reader:
         reader = Zarr2Reader(sample_zarr2_path)
         assert reader.path == sample_zarr2_path
 
-    def test_get_tensorstore_spec(self, sample_zarr2_path):
-        """Test getting TensorStore spec from Zarr2."""
+    def test_get_tensorstore(self, sample_zarr2_path):
+        """Test getting TensorStore from Zarr2."""
         reader = Zarr2Reader(sample_zarr2_path, dataset_path="s0")
-        spec = reader.get_tensorstore_spec()
+        store = reader.get_tensorstore()
 
-        assert spec is not None
-        assert spec['driver'] == 'zarr'
+        assert isinstance(store, ts.TensorStore)
+        assert store.spec().to_json()['driver'] == 'zarr'
 
     def test_factory_method(self, sample_zarr2_path):
         """Test Readers.zarr2() factory method."""
@@ -116,13 +119,13 @@ class TestN5Reader:
         reader = N5Reader(sample_n5_path)
         assert reader.path == sample_n5_path
 
-    def test_get_tensorstore_spec(self, sample_n5_path):
-        """Test getting TensorStore spec from N5."""
+    def test_get_tensorstore(self, sample_n5_path):
+        """Test getting TensorStore from N5."""
         reader = N5Reader(sample_n5_path, dataset_path="s0")
-        spec = reader.get_tensorstore_spec()
+        store = reader.get_tensorstore()
 
-        assert spec is not None
-        assert spec['driver'] == 'n5'
+        assert isinstance(store, ts.TensorStore)
+        assert store.spec().to_json()['driver'] == 'n5'
 
     def test_get_metadata(self, sample_n5_path):
         """Test getting metadata from N5."""
@@ -172,33 +175,20 @@ class TestReaderDataAccess:
     """Tests for actual data access through readers."""
 
     def test_tiff_read_data(self, sample_tiff_path, sample_3d_array):
-        """Test reading data through TiffReader.
-
-        Note: TiffReader is a Tier 2 reader that returns a dask array.
-        The dask array is wrapped in a TensorStore 'array' driver spec,
-        but we access the data through the dask array directly.
-        """
+        """Test reading data through TiffReader."""
         reader = TiffReader(sample_tiff_path)
-        spec = reader.get_tensorstore_spec()
+        store = reader.get_tensorstore()
 
-        # TiffReader uses 'array' driver with dask array
-        assert spec['driver'] == 'array'
-        assert 'array' in spec
-
-        # Access dask array directly and compute
-        dask_array = spec['array']
-        data = dask_array.compute()
+        assert isinstance(store, ts.TensorStore)
+        data = store[...].read().result()
 
         assert data.shape == sample_3d_array.shape
         assert np.array_equal(data, sample_3d_array)
 
     def test_zarr3_read_data(self, sample_zarr3_path, sample_3d_array):
         """Test reading data through Zarr3Reader."""
-        import tensorstore as ts
-
         reader = Zarr3Reader(sample_zarr3_path, dataset_path="s0")
-        spec = reader.get_tensorstore_spec()
-        store = ts.open(spec, read=True).result()
+        store = reader.get_tensorstore()
 
         data = store[...].read().result()
 
@@ -207,11 +197,8 @@ class TestReaderDataAccess:
 
     def test_n5_read_data(self, sample_n5_path, sample_3d_array):
         """Test reading data through N5Reader."""
-        import tensorstore as ts
-
         reader = N5Reader(sample_n5_path, dataset_path="s0")
-        spec = reader.get_tensorstore_spec()
-        store = ts.open(spec, read=True).result()
+        store = reader.get_tensorstore()
 
         data = store[...].read().result()
 


### PR DESCRIPTION
All readers now expose get_tensorstore() -> ts.TensorStore instead of
get_tensorstore_spec() -> dict.

- Add DaskReader(BaseReader) intermediate class in readers/base.py:
  wraps dask arrays via ts.virtual_chunked with a synchronous _read_fn
  callback dispatched on TensorStore's thread pool. Chunk layout is
  aligned to the dask array's native chunk shape.
- Tier 1 readers (N5, Zarr2, Zarr3, Precomputed): rename method and
  call ts.open() internally, returning an opened ts.TensorStore.
- Tier 2 readers (TIFF, ND2, IMS, HDF5, CZI) and Tier 3 (BIOIOReader):
  extend DaskReader; remove sentinel {'driver': 'array', 'array': ...}
  dicts that were never opened with ts.open().
- Converter: remove _is_tier2 branching and _domain_to_slices(); call
  reader.get_tensorstore() uniformly for all formats.
- api/dataset.py, __main__.py: update all call sites accordingly.
- Tests: replace get_tensorstore_spec() assertions with
  store.spec().to_json()['driver'] checks for Tier 1, and
  store[...].read().result() data access for all tiers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
